### PR TITLE
feat: SonarQube integration — frontend pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -48,6 +48,36 @@ pipeline {
       }
     }
 
+    stage('test') {
+      steps {
+        sh 'npm run test:cov'
+      }
+    }
+
+    stage('SonarQube analysis') {
+      steps {
+        script {
+          scannerHome = tool 'SonarQubeScanner'
+        }
+        withSonarQubeEnv('OsgFrontSonarQube') {
+          sh "${scannerHome}/bin/sonar-scanner"
+        }
+      }
+    }
+
+    stage('Sonar Quality Gate') {
+      steps {
+        timeout(time: 1, unit: 'HOURS') {
+          script {
+            def qg = waitForQualityGate()
+            if (qg.status == 'ERROR') {
+              unstable('Quality gate failed')
+            }
+          }
+        }
+      }
+    }
+
     stage('build & push docker image') {
       when {
         expression { env.BRANCH_NAME == 'main' || env.BRANCH_NAME == 'dev'}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,4 @@
+sonar.projectKey=OldSchoolGames-frontend
+sonar.javascript.lcov.reportPaths=./coverage/lcov.info
+sonar.sources=src
+sonar.coverage.exclusions=**/node_modules/**,**/dist/**


### PR DESCRIPTION
## Summary

- Adds `sonar-project.properties` (projectKey, lcov coverage path, sources, exclusions)
- Adds 3 stages to Jenkinsfile after `lint`: `test` (vitest --coverage), `SonarQube analysis` (env: `OsgFrontSonarQube`), `Sonar Quality Gate` (UNSTABLE on failure)

## Test plan

- [ ] Vérifier que le pipeline Jenkins passe les 3 nouveaux stages sans erreur
- [ ] Vérifier que SonarQube reçoit l'analyse et affiche le projet `OldSchoolGames-frontend`
- [ ] Vérifier que le Quality Gate ne bloque pas le build (`UNSTABLE` uniquement)
- [ ] Étapes manuelles ops préalables : créer le projet SonarQube + token + credential Jenkins

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)