### PR TITLE
Story 1.3: UserItem & CropperModal — Fix non-native interactive elements

### DIFF
--- a/src/components/CropperModal/CropperModal.tsx
+++ b/src/components/CropperModal/CropperModal.tsx
@@ -102,7 +102,7 @@ export function CropperModal({ setImage, croppedImage, showModal, setShowModal }
         {
           image &&
           <>
-            <h2>svelte-easy-crop</h2>
+            <h2>Image cropper</h2>
             <div style={{position: 'relative', width: '100%', height: '300px'}}>
               <Cropper
                 image={image}

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -89,7 +89,7 @@ header h1 {
 	grid-template-rows: 0fr;
 	transition: grid-template-rows .2s ease-out;
   overflow: hidden;
-	& span, & button {
+	& span, & button, & a {
 		min-height: 0;
 	}
 }

--- a/src/components/UserItem/UserItem.scss
+++ b/src/components/UserItem/UserItem.scss
@@ -2,6 +2,13 @@
   display: flex;
   align-items: center;
   width: fit-content;
+  border: none;
+  background: none;
+  padding: 0;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
 }
 
 .userItem-avatar {

--- a/src/components/UserItem/UserItem.tsx
+++ b/src/components/UserItem/UserItem.tsx
@@ -16,7 +16,7 @@ export function UserItem({user}: {user: IUser}) {
   const [isGameSelectionOpen, setIsGameSelectionOpen] = useState(false);
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null);
 
-  const handleInviteClick = (event: React.MouseEvent<HTMLElement>) => {
+  const handleInviteClick = (event: React.MouseEvent<HTMLButtonElement>) => {
     setAnchorEl(event.currentTarget);
     if(!user.invite) {
       // TODO switch to chooseGame when implemented
@@ -69,7 +69,8 @@ export function UserItem({user}: {user: IUser}) {
 
   return (
     <>
-    <div
+    <button
+      type="button"
       className="userItem"
       onClick={handleInviteClick}
     >
@@ -91,7 +92,7 @@ export function UserItem({user}: {user: IUser}) {
         <div className="invite-received" >
           <img src="/coucou.gif" alt="invitation received"/>
         </div>}
-    </div>
+    </button>
     {/* Invite sent menu */}
     <Menu
       anchorEl={anchorEl}


### PR DESCRIPTION
Closes #52

## Changes

- `UserItem`: replace `<div onClick>` with `<button type="button">` (SonarQube S6848)
- `UserItem`: update `handleInviteClick` signature to `React.MouseEvent<HTMLButtonElement>`
- `UserItem.scss`: add button CSS resets (`border`, `background`, `padding`, `font`, `color`, `cursor`, `text-align`)
- `CropperModal`: fix `<h2>svelte-easy-crop</h2>` copy/paste artifact → `<h2>Image cropper</h2>`
- `Header.css`: add `& a` to `min-height: 0` rule so Profile link animates correctly in the menu

## Acceptance Criteria

- [x] UserItem uses native `<button>` — keyboard Tab + Enter/Space work
- [x] CropperModal controls already used native `<button>` — h2 label fixed
- [x] All `<img>` have meaningful alt attributes
- [x] `npm run lint` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)