### PR TITLE
fix(sonarqube): resolve Group A cosmetic warnings (S6759, S125, S3863)

### DIFF
--- a/src/components/Box/Box.tsx
+++ b/src/components/Box/Box.tsx
@@ -1,10 +1,10 @@
 import './Box.css'
 import type { JSX } from 'react'
 
-interface Props {
+type Props = Readonly<{
   children: JSX.Element[] | JSX.Element
   className?: string
-}
+}>
 
 export function Box({children, className}: Props) {
 

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -1,12 +1,12 @@
 import './Button.css'
 import type { MouseEvent, ReactNode } from 'react'
 
-interface Props {
+type Props = Readonly<{
   callback?: (e: MouseEvent<HTMLButtonElement>) => void,
   type?: 'button' | 'submit' | 'reset',
   label: string | ReactNode,
   disabled?: boolean,
-}
+}>
 
 export function Button(props : Props) {
 

--- a/src/components/CropperModal/CropperModal.tsx
+++ b/src/components/CropperModal/CropperModal.tsx
@@ -6,12 +6,12 @@ import getCroppedImg from '../../utils/canvasUtils';
 import { Button } from '../Button/Button';
 import './CropperModal.css';
 
-type avatar = {
+type avatar = Readonly<{
   setImage: Dispatch<SetStateAction<string>>;
   croppedImage: string;
   showModal: boolean;
   setShowModal: Dispatch<SetStateAction<boolean>>;
-}
+}>
 
 export function CropperModal({ setImage, croppedImage, showModal, setShowModal }: avatar) {
   const [crop, setCrop] = useState<Point>({ x: 0, y: 0});

--- a/src/components/FormLine/FormLine.tsx
+++ b/src/components/FormLine/FormLine.tsx
@@ -1,13 +1,13 @@
 import type { ChangeEvent } from 'react';
 
-type formLineProps = {
+type formLineProps = Readonly<{
   name: string;
   inputType?: string;
   label?: string;
   value?: string;
   required?: boolean;
   onChange?: (e: ChangeEvent<HTMLInputElement>) => void;
-}
+}>
 
 export function FormLine(props: formLineProps) {
   const inputProps = props.onChange

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -4,7 +4,9 @@ import { Link } from "react-router-dom";
 import { AppContext } from '../../contexts';
 import { Box } from '../Box/Box';
 
-export function Header({ ioClose }: { ioClose?: () => void }) {
+type HeaderProps = Readonly<{ ioClose?: () => void }>;
+
+export function Header({ ioClose }: HeaderProps) {
   useEffect(() => {
     const documentElement = document.querySelector('html');
     

--- a/src/components/NotificationFeed/NotificationFeed.tsx
+++ b/src/components/NotificationFeed/NotificationFeed.tsx
@@ -5,7 +5,9 @@ export interface INotification {
   message: string;
 }
 
-export function NotificationFeed({ notifications }: { notifications: INotification[] }) {
+type NotificationFeedProps = Readonly<{ notifications: INotification[] }>;
+
+export function NotificationFeed({ notifications }: NotificationFeedProps) {
   return (
     <div className="notification-feed">
       {notifications.map((n) => (

--- a/src/components/ProtectedContent.tsx
+++ b/src/components/ProtectedContent.tsx
@@ -1,36 +1,17 @@
 import { useContext, type ReactNode } from 'react';
 import { Navigate } from 'react-router-dom';
 import { AppContext } from '../contexts';
-//import socketIOClient from 'socket.io-client';
 
-type ProtectedContentProps = {
+type ProtectedContentProps = Readonly<{
     children: ReactNode;
-};
+}>;
 
 export const ProtectedContent = ({ children }: ProtectedContentProps) => {
   const appContext = useContext(AppContext);
-  
+
   if(!appContext.appState.accessToken) {
     return <Navigate to="/login" ></Navigate>
   }
-
-  //! not the good place to do this
-  // const socket = socketIOClient(`${import.meta.env.VITE_BACKEND_URL}/events`, {
-	// 	extraHeaders: { Authorization: `Bearer ${appContext.appState.accessToken}` }
-	// });
-
-  // socket.on('connect', () => {
-  //   console.log('WebSocket connected');
-  // });
-  // socket.on('disconnect', () => {
-  //   console.log('WebSocket disconnected');
-  // });
-  // socket.on('error', (error: {error: string, message: string, code: number}) => {
-  //   console.error('WebSocket error:', error);
-  //   localStorage.removeItem('userInfos');
-  //   localStorage.removeItem('accessToken');
-  //   appContext.setAppState({accessToken: '', user: null});
-  // });
 
   return <>{children}</>
 }

--- a/src/components/Switch/Switch.tsx
+++ b/src/components/Switch/Switch.tsx
@@ -1,6 +1,8 @@
 import './Switch.css';
 
-export function Switch(props: { firstIsActive: boolean; switchIndex: () => void; labels: string[]; }) {
+type SwitchProps = Readonly<{ firstIsActive: boolean; switchIndex: () => void; labels: string[] }>;
+
+export function Switch(props: SwitchProps) {
 
   return (
     <button

--- a/src/components/UserItem/UserItem.tsx
+++ b/src/components/UserItem/UserItem.tsx
@@ -1,5 +1,4 @@
-import { useContext, useState} from "react";
-import React from "react";
+import React, { useContext, useState} from "react";
 import type { IUser } from "../../interfaces/events/IUsers";
 import WsContext from "../../contexts/wsContext";
 import Menu from '@mui/material/Menu';
@@ -8,7 +7,9 @@ import MenuItem from '@mui/material/MenuItem';
 import "./UserItem.scss";
 import { Box } from "../Box/Box";
 
-export function UserItem({user}: {user: IUser}) {
+type UserItemProps = Readonly<{ user: IUser }>;
+
+export function UserItem({ user }: UserItemProps) {
   const wsContext = useContext(WsContext);
   const socket = wsContext?.Socket;
   const [isInviteSentOpen, setIsInviteSentOpen] = useState(false);

--- a/src/components/UserList/UserList.tsx
+++ b/src/components/UserList/UserList.tsx
@@ -2,7 +2,9 @@ import type { IUser } from "../../interfaces/events/IUsers";
 import { UserItem } from "../UserItem/UserItem";
 import "./UserList.css"
 
-export function UserList({users}: {users: IUser[]}) {
+type UserListProps = Readonly<{ users: IUser[] }>;
+
+export function UserList({ users }: UserListProps) {
   return (
     <div className="userList">
       <span className="userList-title">On line :</span>

--- a/src/pages/Game/GameBoard.tsx
+++ b/src/pages/Game/GameBoard.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 
-interface GameBoardProps {
+type GameBoardProps = Readonly<{
   cols: string;
   rows: string;
   width: string;
   handleCellClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
   cellsContent?: Record<string, React.ReactNode>;
-}
+}>;
 
 export function GameBoard(props: GameBoardProps) {
   const cells = [];

--- a/src/providers/AppProvider.tsx
+++ b/src/providers/AppProvider.tsx
@@ -2,9 +2,9 @@ import { useEffect, useMemo, useState, type ReactNode } from "react";
 import { type Appstate } from "../contexts/appContext";
 import { AppContext } from "../contexts";
 
-type AppProps = {
+type AppProps = Readonly<{
   children: ReactNode
-}
+}>
 
 function AppProvider({children} : AppProps) {
   

--- a/src/providers/WsProvider.tsx
+++ b/src/providers/WsProvider.tsx
@@ -3,9 +3,9 @@ import socketIOClient from "socket.io-client";
 
 import WsContext from "../contexts/wsContext";
 
-type IoSocketProviderProps = {
+type IoSocketProviderProps = Readonly<{
     children: ReactNode
-}
+}>
 
 function WsProvider({children} : IoSocketProviderProps) {
     let ioUrl: string = "";

--- a/src/utils/canvasUtils.tsx
+++ b/src/utils/canvasUtils.tsx
@@ -82,13 +82,5 @@ export default async function getCroppedImg(
   // paste generated rotate image at the top left corner
   ctx.putImageData(data, 0, 0)
 
-  // As Base64 string
-   return canvas.toDataURL('image/jpeg');
-
-  // As a blob
-//   return new Promise((resolve, reject) => {
-//     canvas.toBlob((file) => {
-//       resolve(URL.createObjectURL(file))
-//     }, 'image/jpeg')
-//   })
+  return canvas.toDataURL('image/jpeg');
 }


### PR DESCRIPTION
Closes #62
Part of #49

## Summary

- **S6759** — Wrap all component prop types with `Readonly<>` (14 files: Box, Button, CropperModal, FormLine, Header, NotificationFeed, ProtectedContent, Switch, UserItem, UserList, GameBoard, AppProvider, WsProvider)
- **S125** — Remove commented-out dead code (`ProtectedContent.tsx`: old socketIO block; `canvasUtils.tsx`: blob alternative)
- **S3863** — Merge duplicate React imports in `UserItem.tsx`

## Test plan

- [ ] `npm run lint` passes (verified locally)
- [ ] No runtime regression — all 3 game pages, dashboard, profile, login functional
- [ ] Verify SonarQube Group A warnings cleared on next scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)