### PR TITLE
feat(validation): create shared validation module (story 2.1)

### DIFF
--- a/src/utils/validation.test.ts
+++ b/src/utils/validation.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { validatePassword, createPseudoChecker } from './validation';
+
+describe('validatePassword', () => {
+  it('returns all false for empty string', () => {
+    expect(validatePassword('')).toEqual({
+      length: false,
+      uppercase: false,
+      lowercase: false,
+      digit: false,
+      special: false,
+    });
+  });
+
+  it('detects length criterion (8–16 chars)', () => {
+    expect(validatePassword('abcdefg').length).toBe(false);   // 7
+    expect(validatePassword('abcdefgh').length).toBe(true);   // 8
+    expect(validatePassword('abcdefghijklmnop').length).toBe(true);  // 16
+    expect(validatePassword('abcdefghijklmnopq').length).toBe(false); // 17
+  });
+
+  it('detects uppercase criterion', () => {
+    expect(validatePassword('abcdef1!').uppercase).toBe(false);
+    expect(validatePassword('Abcdef1!').uppercase).toBe(true);
+  });
+
+  it('detects lowercase criterion', () => {
+    expect(validatePassword('ABCDEF1!').lowercase).toBe(false);
+    expect(validatePassword('ABCDEf1!').lowercase).toBe(true);
+  });
+
+  it('detects digit criterion', () => {
+    expect(validatePassword('Abcdefg!').digit).toBe(false);
+    expect(validatePassword('Abcdef1!').digit).toBe(true);
+  });
+
+  it('detects special character criterion', () => {
+    expect(validatePassword('Abcdef12').special).toBe(false);
+    expect(validatePassword('Abcdef1!').special).toBe(true);
+  });
+
+  it('returns all true for a fully valid password', () => {
+    expect(validatePassword('Abcdef1!')).toEqual({
+      length: true,
+      uppercase: true,
+      lowercase: true,
+      digit: true,
+      special: true,
+    });
+  });
+});
+
+describe('createPseudoChecker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('fires checkFn only for the last call within 1000ms (debounce)', async () => {
+    const checkFn = vi.fn().mockResolvedValue(true);
+    const callback = vi.fn();
+    const checker = createPseudoChecker(checkFn);
+
+    checker('a', callback);
+    checker('ab', callback);
+    checker('abc', callback);
+
+    expect(checkFn).not.toHaveBeenCalled();
+
+    await vi.runAllTimersAsync();
+
+    expect(checkFn).toHaveBeenCalledTimes(1);
+    expect(checkFn).toHaveBeenCalledWith('abc');
+    expect(callback).toHaveBeenCalledWith(true);
+  });
+
+  it('does not fire a new call while a previous one is in-flight', async () => {
+    let resolveFirst!: (v: boolean) => void;
+    const firstCallPromise = new Promise<boolean>((res) => { resolveFirst = res; });
+
+    const checkFn = vi.fn()
+      .mockReturnValueOnce(firstCallPromise)
+      .mockResolvedValue(true);
+
+    const callback = vi.fn();
+    const checker = createPseudoChecker(checkFn);
+
+    // First call — timer fires, in-flight starts
+    checker('abc', callback);
+    await vi.runAllTimersAsync();
+    expect(checkFn).toHaveBeenCalledTimes(1);
+
+    // Second call while first is still in-flight
+    checker('abcd', callback);
+    await vi.runAllTimersAsync();
+    // checkFn must NOT be called again
+    expect(checkFn).toHaveBeenCalledTimes(1);
+
+    // First call resolves
+    resolveFirst(true);
+    await Promise.resolve();
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/utils/validation.ts
+++ b/src/utils/validation.ts
@@ -1,0 +1,30 @@
+export const PASSWORD_REGEX = /^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*[!@#$%^&*()\-_=+[\]{}|;':",.<>?/\\]).{8,16}$/;
+
+export function validatePassword(value: string) {
+  return {
+    length: value.length >= 8 && value.length <= 16,
+    uppercase: /[A-Z]/.test(value),
+    lowercase: /[a-z]/.test(value),
+    digit: /[0-9]/.test(value),
+    special: /[!@#$%^&*()\-_=+[\]{}|;':",.<>?/\\]/.test(value),
+  };
+}
+
+export function createPseudoChecker(checkFn: (pseudo: string) => Promise<boolean>) {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let inFlight = false;
+
+  return (pseudo: string, callback: (available: boolean) => void) => {
+    if (timer) clearTimeout(timer);
+    timer = setTimeout(async () => {
+      if (inFlight) return;
+      inFlight = true;
+      try {
+        const available = await checkFn(pseudo);
+        callback(available);
+      } finally {
+        inFlight = false;
+      }
+    }, 1000);
+  };
+}


### PR DESCRIPTION
Closes #54
Part of #16

## Summary

- `src/utils/validation.ts` — nouveau module partagé
  - `PASSWORD_REGEX` — regex conforme à la règle backend (8–16 chars, upper, lower, digit, special)
  - `validatePassword(value)` — retourne `{ length, uppercase, lowercase, digit, special }` pour le checklist de saisie
  - `createPseudoChecker(checkFn)` — factory debounce 1000ms + garde in-flight, sans dépendance externe
- `src/utils/validation.test.ts` — 9 tests vitest (critères individuels, password complet, debounce, in-flight guard)

## Test plan

- [x] `vitest run src/utils/validation.test.ts` — 9/9 passed
- [x] `npm run lint` — no errors
- [ ] Vérifier que les stories 2.3/2.4/2.5 importent bien depuis ce module (consommé dans les prochaines stories)

🤖 Generated with [Claude Code](https://claude.com/claude-code)