### PR TITLE
feat(icons): create SVG icon system and validation color tokens (story 2.2)

### DIFF
--- a/src/assets/icons/InvalidIcon.tsx
+++ b/src/assets/icons/InvalidIcon.tsx
@@ -1,0 +1,23 @@
+type InvalidIconProps = Readonly<{
+  className?: string;
+  size?: number;
+}>;
+
+export default function InvalidIcon({ className, size = 12 }: InvalidIconProps) {
+  return (
+    <svg
+      viewBox="0 0 12 12"
+      width={size}
+      height={size}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <line x1="2" y1="2" x2="10" y2="10" />
+      <line x1="10" y1="2" x2="2" y2="10" />
+    </svg>
+  );
+}

--- a/src/assets/icons/ValidIcon.tsx
+++ b/src/assets/icons/ValidIcon.tsx
@@ -1,0 +1,23 @@
+type ValidIconProps = Readonly<{
+  className?: string;
+  size?: number;
+}>;
+
+export default function ValidIcon({ className, size = 12 }: ValidIconProps) {
+  return (
+    <svg
+      viewBox="0 0 12 12"
+      width={size}
+      height={size}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+    >
+      <polyline points="2,6 5,9 10,3" />
+    </svg>
+  );
+}

--- a/src/assets/icons/icons.css
+++ b/src/assets/icons/icons.css
@@ -1,0 +1,19 @@
+@keyframes typewriter {
+  from { max-width: 0; }
+  to   { max-width: 100%; }
+}
+
+@keyframes fadeDown {
+  from { opacity: 1; transform: translateY(0); }
+  to   { opacity: 0; transform: translateY(4px); }
+}
+
+.error-message {
+  overflow: hidden;
+  white-space: nowrap;
+  animation: typewriter 300ms steps(20, end) forwards;
+}
+
+.error-message--exit {
+  animation: fadeDown 200ms ease-out forwards;
+}

--- a/src/assets/icons/icons.test.tsx
+++ b/src/assets/icons/icons.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import ValidIcon from './ValidIcon';
+import InvalidIcon from './InvalidIcon';
+
+describe('ValidIcon', () => {
+  it('renders an SVG element', () => {
+    const { container } = render(<ValidIcon />);
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('uses currentColor — no hardcoded fill or stroke color', () => {
+    const { container } = render(<ValidIcon />);
+    const svg = container.querySelector('svg')!;
+    const allElements = [svg, ...Array.from(svg.querySelectorAll('*'))];
+    for (const el of allElements) {
+      const fill = el.getAttribute('fill');
+      const stroke = el.getAttribute('stroke');
+      if (fill && fill !== 'none' && fill !== 'currentColor') {
+        throw new Error(`Hardcoded fill found: ${fill}`);
+      }
+      if (stroke && stroke !== 'none' && stroke !== 'currentColor') {
+        throw new Error(`Hardcoded stroke found: ${stroke}`);
+      }
+    }
+  });
+
+  it('applies custom size prop', () => {
+    const { container } = render(<ValidIcon size={24} />);
+    const svg = container.querySelector('svg')!;
+    expect(svg.getAttribute('width')).toBe('24');
+    expect(svg.getAttribute('height')).toBe('24');
+  });
+
+  it('applies custom className prop', () => {
+    const { container } = render(<ValidIcon className="my-icon" />);
+    expect(container.querySelector('svg')!.classList.contains('my-icon')).toBe(true);
+  });
+});
+
+describe('InvalidIcon', () => {
+  it('renders an SVG element', () => {
+    const { container } = render(<InvalidIcon />);
+    expect(container.querySelector('svg')).not.toBeNull();
+  });
+
+  it('uses currentColor — no hardcoded fill or stroke color', () => {
+    const { container } = render(<InvalidIcon />);
+    const svg = container.querySelector('svg')!;
+    const allElements = [svg, ...Array.from(svg.querySelectorAll('*'))];
+    for (const el of allElements) {
+      const fill = el.getAttribute('fill');
+      const stroke = el.getAttribute('stroke');
+      if (fill && fill !== 'none' && fill !== 'currentColor') {
+        throw new Error(`Hardcoded fill found: ${fill}`);
+      }
+      if (stroke && stroke !== 'none' && stroke !== 'currentColor') {
+        throw new Error(`Hardcoded stroke found: ${stroke}`);
+      }
+    }
+  });
+
+  it('applies custom size prop', () => {
+    const { container } = render(<InvalidIcon size={16} />);
+    const svg = container.querySelector('svg')!;
+    expect(svg.getAttribute('width')).toBe('16');
+    expect(svg.getAttribute('height')).toBe('16');
+  });
+
+  it('applies custom className prop', () => {
+    const { container } = render(<InvalidIcon className="err-icon" />);
+    expect(container.querySelector('svg')!.classList.contains('err-icon')).toBe(true);
+  });
+});

--- a/src/index.css
+++ b/src/index.css
@@ -1,5 +1,10 @@
 @import url('https://fonts.googleapis.com/css2?family=Sixtyfour&display=swap');
 
+:root {
+	--red-error: #c52f2f;
+	--red-border: #8b2020;
+}
+
 html, #root {
 	height: 100dvh;
 }


### PR DESCRIPTION
Closes #55
Part of #16

## Summary

- `src/index.css` — ajout de `--red-error: #c52f2f` et `--red-border: #8b2020` dans `:root`
- `src/assets/icons/ValidIcon.tsx` — checkmark SVG en `currentColor`, props `size` et `className`
- `src/assets/icons/InvalidIcon.tsx` — croix SVG en `currentColor`, props `size` et `className`
- `src/assets/icons/icons.css` — `@keyframes typewriter` (300ms, steps) et `fadeDown` (200ms ease-out), classes `.error-message` et `.error-message--exit`

## Test plan

- [x] `vitest run` — 44/44 tests passent (8 nouveaux + 36 existants)
- [x] `npm run lint` — aucune erreur
- [ ] Vérifier visuellement l'apparence des icônes dans les stories 2.3/2.4/2.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)