### PR TITLE
feat(header): responsive breakpoints for mobile/tablet viewports

### DIFF
--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -108,3 +108,78 @@ button.menuItem {
 .logthumb.expanded .menuItem {
 	grid-template-rows: 1fr;
 }
+
+@media (max-width: 1550px) {
+	header h1 {
+		font-size: 32px;
+		padding-top: 25px;
+	}
+	header {
+		height: 80px;
+		background-position: left 20px top 0;
+		background-size: 80px;
+	}
+	.logthumb {
+		font-size: 12px;
+	}
+}
+
+.logMenu-mobile-only {
+	display: none;
+}
+
+@media (max-width: 1200px) {
+	header h1 {
+		font-size: 24px;
+		padding-top: 20px;
+	}
+	header {
+		height: 60px;
+		background-position: left 20px top 0;
+		background-size: 60px;
+	}
+	.logthumb {
+		font-size: 10px;
+	}
+	.logbar {
+		justify-content: flex-end;
+	}
+	.logbar .logout-btn {
+		display: none;
+	}
+	.logbar .logLabel span {
+		display: none;
+	}
+	.logMenu-mobile-only {
+		display: grid;
+	}
+}
+
+@media (max-width: 750px) {
+	header {
+		height: 40px;
+		background-size: 40px;
+	}
+	header h1 {
+		font-size: 20px;
+		padding-top: 10px;
+	}
+	.logthumb {
+		top: 6px;
+		right: 4px;
+		padding: 0;
+		& .logLabel .logAvatar {
+			height: 26px;
+			width: 26px;
+			border-radius: 13px;
+			margin-right: 0;
+		}
+	}
+}
+	
+@media (max-width: 750px) {
+	header h1 {
+		font-size: 16px;
+		padding-top: 10px;
+	}
+}

--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -61,6 +61,9 @@ export function Header({ ioClose }: HeaderProps) {
             </button>
           </div>
           <Box className="logMenu">
+            <div className="menuItem logMenu-mobile-only">
+              <span>{appContext.appState.user.pseudo}</span>
+            </div>
             <div className="menuItem">
               <Link to='/profile' onClick={collapseMenu}>
                 Profile


### PR DESCRIPTION
Closes #75

## Summary
- CSS-only `@media` breakpoints added to `Header.css` at 1550px, 1200px and 750px
- Header height, `h1` font-size and background logo scale down progressively
- At ≤ 1200px: pseudo and logout button hidden from `.logbar`, duplicated into `.logMenu` (`.logMenu-mobile-only`) to avoid overlap with the shrunken header
- No JavaScript — pure CSS media queries

## Test plan
- [x] Visual verification at 375px, 430px, 768px and 1024px+ (done by Whitedog)
- [x] `.logthumb` positioning verified at all breakpoints — no overlap with `h1`
- [x] Retro terminal aesthetic preserved (colors, font, box-shadow unchanged)
- [x] Lint passed

Part of #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)