### PR TITLE
feat(responsive): Login form responsive layout (story 3.7)

### DIFF
--- a/src/components/LoginForm/LoginForm.tsx
+++ b/src/components/LoginForm/LoginForm.tsx
@@ -255,6 +255,7 @@ export function LoginForm() {
         setShowModal={setIsOpen}
       />
       <div className="login-page">
+        <div className="login-form-wrapper">
         <Switch
           labels={['login', 'register']}
           switchIndex={switchIndex}
@@ -359,6 +360,7 @@ export function LoginForm() {
             />
           </form>
         </Box>
+        </div>
         {errorMessage && <div className="server-error">{errorMessage}</div>}
         {avatarWarning && (
           <div className="avatar-warning">

--- a/src/components/LoginForm/loginForm.css
+++ b/src/components/LoginForm/loginForm.css
@@ -127,3 +127,39 @@ form {
     margin: 0 0 8px 0;
   }
 }
+
+.login-form-wrapper {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: stretch;
+}
+
+@media (max-width: 750px) {
+  .login-page {
+    width: 100%;
+    padding: 0 12px;
+    box-sizing: border-box;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+  .form-line {
+    & input {
+      margin-top: 12px;
+      margin-bottom: 12px;
+    }
+  }
+}
+
+@media (max-width: 479px) {
+  .form-line {
+    column-gap: 10px;
+    & input {
+      width: 150px;
+    }
+  }
+  .avatar-preview-container {
+    width: 70px;
+    height: 70px;
+  }
+}


### PR DESCRIPTION
## Summary

- Added `.login-form-wrapper` div in `LoginForm.tsx` to align Switch width with Box at all breakpoints (`inline-flex; align-items: stretch`)
- `≤750px`: `.login-page` centers wrapper via flex, `.form-line input` gets `margin-top/bottom: 12px` for touch accessibility
- `≤479px`: `.form-line` column-gap 10px, input width 150px, avatar preview 70×70px
- `.formBox` in `Login.css` confirmed unused — no change needed

Closes #79

## Test plan

- [x] Login mode at 375px: no horizontal overflow, inputs accessible
- [x] Register mode at 375px: expanded form scrolls, avatar 70×70
- [x] Switch matches form width at all breakpoints
- [x] 750px threshold: layout transitions correctly
- [x] 1024px+: no regression vs current layout
- [x] Retro aesthetic preserved (colors, font, borders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)