### PR TITLE
feat(responsive): GameBoard fluid layout + jouability guard (stories 3.1 & 3.2)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+*.bat text eol=crlf

--- a/src/index.css
+++ b/src/index.css
@@ -16,6 +16,12 @@ html, #root {
 	overflow: hidden;
 }
 
+.home-content {
+	flex: 1;
+	min-height: 0;
+	overflow: hidden;
+}
+
 body {
 	margin: 0;
 	padding: 0;

--- a/src/pages/Dashboard/Dashboard.css
+++ b/src/pages/Dashboard/Dashboard.css
@@ -1,7 +1,7 @@
 .dashboard {
   display: grid;
   grid-template-columns: minmax(min-content, 20%) 1fr;
-  flex: 1;
+  height: 100%;
   overflow: hidden;
 }
 

--- a/src/pages/Game/GameBoard.css
+++ b/src/pages/Game/GameBoard.css
@@ -31,6 +31,23 @@
   color: inherit;
 }
 
+.reload-handler {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 300ms ease-out;
+  overflow: hidden;
+  text-align: center;
+}
+
+.reload-handler--open {
+  grid-template-rows: 1fr;
+}
+
+.reload-handler__inner {
+  min-height: 0;
+  overflow: hidden;
+}
+
 .jouability-guard {
   display: none;
   text-align: center;

--- a/src/pages/Game/GameBoard.css
+++ b/src/pages/Game/GameBoard.css
@@ -1,0 +1,47 @@
+.GameBoard {
+  width: min(100cqw, calc(100cqh * var(--cols) / var(--rows)));
+  aspect-ratio: var(--cols) / var(--rows);
+  border: 11px solid green;
+  border-image: url('/box_border.png') 11 stretch;
+  border-radius: 12px;
+  box-shadow: 3px 3px 6px #306b30;
+  overflow: hidden;
+  box-sizing: border-box;
+  container-type: inline-size;
+}
+
+.game-grid {
+  display: grid;
+  width: 100%;
+  height: 100%;
+  grid-template-columns: repeat(var(--cols), 1fr);
+  grid-template-rows: repeat(var(--rows), 1fr);
+}
+
+.cells {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: min(5cqi, 2em);
+  background: none;
+  padding: 0;
+  cursor: pointer;
+  color: inherit;
+}
+
+.jouability-guard {
+  display: none;
+  text-align: center;
+  padding: 20px;
+}
+
+@container (max-width: calc(var(--min-playable-width) - 1px)) {
+  .jouability-guard {
+    display: block;
+  }
+  .game-grid {
+    display: none;
+  }
+}

--- a/src/pages/Game/GameBoard.tsx
+++ b/src/pages/Game/GameBoard.tsx
@@ -1,39 +1,35 @@
 import React from 'react';
+import './GameBoard.css';
 
 type GameBoardProps = Readonly<{
   cols: string;
   rows: string;
-  width: string;
+  gameName: string;
   handleCellClick: (event: React.MouseEvent<HTMLButtonElement>) => void;
   cellsContent?: Record<string, React.ReactNode>;
 }>;
 
 export function GameBoard(props: GameBoardProps) {
   const cells = [];
-  for(let i = 1; i <= Number(props.rows); i++) {
-    for(let j = 1; j <= Number(props.cols); j++) {
+  for (let i = 1; i <= Number(props.rows); i++) {
+    for (let j = 1; j <= Number(props.cols); j++) {
       cells.push(`c${j}${i}`);
     }
   }
 
-  let gridColumns = '';
-  for(let i=1; i<= Number(props.cols); i++) {
-    gridColumns += ' 1fr';
-  }
-
-  const cellSize = Number(props.width) / Number(props.cols);
-
   return (
-    <div className="GameBoard">
-      <div
-        className="game-grid"
-        style={{
-          display: 'grid',
-          width: `${props.width}px`,
-          height: `${cellSize * Number(props.rows)}px`,
-          gridTemplateColumns: gridColumns,
-        }}
-      >
+    <div
+      className="GameBoard"
+      style={{
+        '--cols': props.cols,
+        '--rows': props.rows,
+        '--min-playable-width': `calc(${props.cols} * 44px)`,
+      } as React.CSSProperties}
+    >
+      <div className="jouability-guard">
+        Screen too small to play {props.gameName}. Try on a larger device or rotate your screen.
+      </div>
+      <div className="game-grid">
         {cells.map((cell) => (
           <button
             id={cell}
@@ -43,24 +39,14 @@ export function GameBoard(props: GameBoardProps) {
               borderTop: 'none',
               borderLeft: 'none',
               borderBottom: Number(cell.substring(2)) === Number(props.rows) ? 'none' : '1px solid green',
-              borderRight: Number(cell.substring(1,2)) === Number(props.cols) ? 'none' : '1px solid green',
+              borderRight: Number(cell.substring(1, 2)) === Number(props.cols) ? 'none' : '1px solid green',
               borderImage: 'none',
               borderRadius: 0,
-              width: `${cellSize}px`,
-              height: `${cellSize}px`,
-              display: 'flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              fontSize: cellSize * 0.2,
-              background: 'none',
-              padding: 0,
-              cursor: 'pointer',
-              color: 'inherit',
             }}
             onClick={props.handleCellClick}
           >{props.cellsContent?.[cell]}</button>
         ))}
       </div>
     </div>
-  )
+  );
 }

--- a/src/pages/Game/Morpion/Morpion.scss
+++ b/src/pages/Game/Morpion/Morpion.scss
@@ -18,9 +18,6 @@
     align-items: center;
     justify-content: center;
   }
-  & .reload-handler {
-    text-align: center;
-  }
   & .reload-buttons {
     display: flex;
     width: fit-content;

--- a/src/pages/Game/Morpion/Morpion.scss
+++ b/src/pages/Game/Morpion/Morpion.scss
@@ -1,10 +1,22 @@
 .Morpion {
-  & .game-grid {
-    margin: 5px;
-  }
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  justify-items: center;
+  height: 100%;
   & #game-turn-data {
     text-align: center;
-    padding: 20px 0;
+    margin: 20px 0;
+  }
+  & .game-area {
+    width: 100%;
+    height: 100%;
+    padding: 10px;
+    box-sizing: border-box;
+    container-type: size;
+    container-name: game-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
   & .reload-handler {
     text-align: center;
@@ -14,7 +26,7 @@
     width: fit-content;
     margin: auto;
     & .button_wrapper {
-      margin : 10px;
+      margin: 10px;
     }
   }
 }

--- a/src/pages/Game/Morpion/Morpion.tsx
+++ b/src/pages/Game/Morpion/Morpion.tsx
@@ -103,15 +103,13 @@ export function Morpion() {
       <div className="game-area">
         <GameBoard cols='3' rows='3' gameName='Morpion' handleCellClick={handleCellClick} cellsContent={cells} />
       </div>
-      <div className='reload-handler'>
-        {gameEnded && !reloadRequestedBy.includes(appContext.appState.user?.pseudo as string) && (
-          <div className='reload-buttons'><Button type='button' callback={() => navigate('/')} label="❌ Quitter la partie"/><Button type='button' callback={() => requestReload()} label="✅ rejouer" /></div>
-        )}
-        {
-          gameEnded && (
-            <p>{appContext.appState.user?.pseudo} {reloadRequestedBy.includes(appContext.appState.user?.pseudo as string) ? '✅' : ''} | {reloadRequestedBy.includes(opponent ?? '') ? '✅' : ''} {opponent}</p>
-          )
-        }
+      <div className={`reload-handler${gameEnded ? ' reload-handler--open' : ''}`}>
+        <div className="reload-handler__inner">
+          {!reloadRequestedBy.includes(appContext.appState.user?.pseudo as string) && (
+            <div className='reload-buttons'><Button type='button' callback={() => navigate('/')} label="❌ Quitter la partie"/><Button type='button' callback={() => requestReload()} label="✅ rejouer" /></div>
+          )}
+          <p>{appContext.appState.user?.pseudo} {reloadRequestedBy.includes(appContext.appState.user?.pseudo as string) ? '✅' : ''} | {reloadRequestedBy.includes(opponent ?? '') ? '✅' : ''} {opponent}</p>
+        </div>
       </div>
     </div>
   )

--- a/src/pages/Game/Morpion/Morpion.tsx
+++ b/src/pages/Game/Morpion/Morpion.tsx
@@ -2,7 +2,7 @@ import { useLocation, useNavigate } from 'react-router'
 import { useContext, useEffect, useCallback, useRef, useState } from 'react';
 import { GameBoard } from "../GameBoard";
 import { WsContext, AppContext } from "../../../contexts";
-import { Box, Button } from '../../../components';
+import { Button } from '../../../components';
 import type { IGameEventData } from "../../../interfaces/events/IGame";
 
 import './Morpion.scss';
@@ -100,7 +100,9 @@ export function Morpion() {
   return (
     <div className="Morpion">
       <div id="game-turn-data">{turn}</div>
-      <Box><GameBoard cols='3' rows='3' width='300' handleCellClick={handleCellClick} cellsContent={cells} /></Box>
+      <div className="game-area">
+        <GameBoard cols='3' rows='3' gameName='Morpion' handleCellClick={handleCellClick} cellsContent={cells} />
+      </div>
       <div className='reload-handler'>
         {gameEnded && !reloadRequestedBy.includes(appContext.appState.user?.pseudo as string) && (
           <div className='reload-buttons'><Button type='button' callback={() => navigate('/')} label="❌ Quitter la partie"/><Button type='button' callback={() => requestReload()} label="✅ rejouer" /></div>

--- a/src/pages/Game/Puissance4/Puissance4.scss
+++ b/src/pages/Game/Puissance4/Puissance4.scss
@@ -18,9 +18,6 @@
     align-items: center;
     justify-content: center;
   }
-  & .reload-handler {
-    text-align: center;
-  }
   & .reload-buttons {
     display: flex;
     width: fit-content;

--- a/src/pages/Game/Puissance4/Puissance4.scss
+++ b/src/pages/Game/Puissance4/Puissance4.scss
@@ -1,10 +1,22 @@
 .Puissance4 {
-  & .game-grid {
-    margin: 5px;
-  }
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  justify-items: center;
+  height: 100%;
   & #game-turn-data {
     text-align: center;
-    padding: 20px 0;
+    margin: 20px 0;
+  }
+  & .game-area {
+    width: 100%;
+    height: 100%;
+    padding: 10px;
+    box-sizing: border-box;
+    container-type: size;
+    container-name: game-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
   & .reload-handler {
     text-align: center;
@@ -14,7 +26,7 @@
     width: fit-content;
     margin: auto;
     & .button_wrapper {
-      margin : 10px;
+      margin: 10px;
     }
   }
 }

--- a/src/pages/Game/Puissance4/Puissance4.tsx
+++ b/src/pages/Game/Puissance4/Puissance4.tsx
@@ -2,7 +2,7 @@ import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { WsContext, AppContext } from "../../../contexts";
 import { GameBoard } from "../GameBoard";
-import { Box, Button } from '../../../components';
+import { Button } from '../../../components';
 import type { IGameEventData } from "../../../interfaces/events/IGame";
 
 import './Puissance4.scss'
@@ -138,7 +138,9 @@ export function Puissance4() {
 
   return <div className="Puissance4">
     <div id="game-turn-data">{turn}</div>
-    <Box><GameBoard cols='7' rows='6' width='350' handleCellClick={handleCellClick} cellsContent={cells} /></Box>
+    <div className="game-area">
+      <GameBoard cols='7' rows='6' gameName='Puissance 4' handleCellClick={handleCellClick} cellsContent={cells} />
+    </div>
     <div className='reload-handler'>
         {gameEnded && !reloadRequestedBy.includes(appContext.appState.user?.pseudo as string) && (
           <div className='reload-buttons'><Button type='button' callback={() => navigate('/')} label="❌ Quitter la partie"/><Button type='button' callback={() => requestReload()} label="✅ rejouer" /></div>

--- a/src/pages/Game/Puissance4/Puissance4.tsx
+++ b/src/pages/Game/Puissance4/Puissance4.tsx
@@ -141,15 +141,13 @@ export function Puissance4() {
     <div className="game-area">
       <GameBoard cols='7' rows='6' gameName='Puissance 4' handleCellClick={handleCellClick} cellsContent={cells} />
     </div>
-    <div className='reload-handler'>
-        {gameEnded && !reloadRequestedBy.includes(appContext.appState.user?.pseudo as string) && (
+    <div className={`reload-handler${gameEnded ? ' reload-handler--open' : ''}`}>
+      <div className="reload-handler__inner">
+        {!reloadRequestedBy.includes(appContext.appState.user?.pseudo as string) && (
           <div className='reload-buttons'><Button type='button' callback={() => navigate('/')} label="❌ Quitter la partie"/><Button type='button' callback={() => requestReload()} label="✅ rejouer" /></div>
         )}
-        {
-          gameEnded && (
-            <p>{appContext.appState.user?.pseudo} {reloadRequestedBy.includes(appContext.appState.user?.pseudo as string) ? '✅' : ''} | {reloadRequestedBy.includes(opponent ?? '') ? '✅' : ''} {opponent}</p>
-          )
-        }
+        <p>{appContext.appState.user?.pseudo} {reloadRequestedBy.includes(appContext.appState.user?.pseudo as string) ? '✅' : ''} | {reloadRequestedBy.includes(opponent ?? '') ? '✅' : ''} {opponent}</p>
       </div>
+    </div>
   </div>
 }

--- a/src/pages/Game/Reversi/Reversi.scss
+++ b/src/pages/Game/Reversi/Reversi.scss
@@ -1,13 +1,26 @@
 .Reversi {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 16px;
-  padding: 16px;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  justify-items: center;
+  height: 100%;
 
   #game-turn-data {
     font-size: 1.1rem;
     font-weight: bold;
+    text-align: center;
+    margin: 20px 0;
+  }
+
+  .game-area {
+    width: 100%;
+    height: 100%;
+    padding: 10px;
+    box-sizing: border-box;
+    container-type: size;
+    container-name: game-box;
+    display: flex;
+    align-items: center;
+    justify-content: center;
   }
 
   .reload-handler {
@@ -15,6 +28,7 @@
     flex-direction: column;
     align-items: center;
     gap: 8px;
+    text-align: center;
 
     .reload-buttons {
       display: flex;

--- a/src/pages/Game/Reversi/Reversi.tsx
+++ b/src/pages/Game/Reversi/Reversi.tsx
@@ -182,18 +182,18 @@ export function Reversi() {
       <div className="game-area">
         <GameBoard cols='8' rows='8' gameName='Reversi' handleCellClick={handleCellClick} cellsContent={cells} />
       </div>
-      <div className='reload-handler'>
-        {gameEnded && !reloadRequestedBy.includes(appContext.appState.user?.pseudo as string) && (
-          <div className='reload-buttons'>
-            <Button type='button' callback={() => navigate('/')} label="❌ Quitter la partie" />
-            <Button type='button' callback={() => requestReload()} label="✅ Rejouer" />
-          </div>
-        )}
-        {gameEnded && (
+      <div className={`reload-handler${gameEnded ? ' reload-handler--open' : ''}`}>
+        <div className="reload-handler__inner">
+          {!reloadRequestedBy.includes(appContext.appState.user?.pseudo as string) && (
+            <div className='reload-buttons'>
+              <Button type='button' callback={() => navigate('/')} label="❌ Quitter la partie" />
+              <Button type='button' callback={() => requestReload()} label="✅ Rejouer" />
+            </div>
+          )}
           <p>
             {appContext.appState.user?.pseudo} {reloadRequestedBy.includes(appContext.appState.user?.pseudo as string) ? '✅' : ''} | {reloadRequestedBy.includes(opponent ?? '') ? '✅' : ''} {opponent}
           </p>
-        )}
+        </div>
       </div>
     </div>
   );

--- a/src/pages/Game/Reversi/Reversi.tsx
+++ b/src/pages/Game/Reversi/Reversi.tsx
@@ -2,7 +2,7 @@ import { useCallback, useContext, useEffect, useRef, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { WsContext, AppContext } from '../../../contexts';
 import { GameBoard } from '../GameBoard';
-import { Box, Button } from '../../../components';
+import { Button } from '../../../components';
 import type { IGameEventData } from '../../../interfaces/events/IGame';
 
 import './Reversi.scss';
@@ -179,9 +179,9 @@ export function Reversi() {
   return (
     <div className="Reversi">
       <div id="game-turn-data">{turn}</div>
-      <Box>
-        <GameBoard cols='8' rows='8' width='400' handleCellClick={handleCellClick} cellsContent={cells} />
-      </Box>
+      <div className="game-area">
+        <GameBoard cols='8' rows='8' gameName='Reversi' handleCellClick={handleCellClick} cellsContent={cells} />
+      </div>
       <div className='reload-handler'>
         {gameEnded && !reloadRequestedBy.includes(appContext.appState.user?.pseudo as string) && (
           <div className='reload-buttons'>

--- a/src/pages/Game/_tests/GameBoard.spec.tsx
+++ b/src/pages/Game/_tests/GameBoard.spec.tsx
@@ -7,12 +7,12 @@ const noop = vi.fn();
 
 describe('GameBoard', () => {
   it('renders cols × rows cells', () => {
-    render(<GameBoard cols="3" rows="3" width="300" handleCellClick={noop} />);
+    render(<GameBoard cols="3" rows="3" gameName="Morpion" handleCellClick={noop} />);
     expect(screen.getAllByRole('button').filter(el => el.classList.contains('cells'))).toHaveLength(9);
   });
 
   it('generates cell IDs with pattern c${col}${row}', () => {
-    render(<GameBoard cols="3" rows="3" width="300" handleCellClick={noop} />);
+    render(<GameBoard cols="3" rows="3" gameName="Morpion" handleCellClick={noop} />);
     expect(document.getElementById('c11')).toBeInTheDocument();
     expect(document.getElementById('c31')).toBeInTheDocument();
     expect(document.getElementById('c13')).toBeInTheDocument();
@@ -21,19 +21,19 @@ describe('GameBoard', () => {
 
   it('calls handleCellClick when a cell is clicked', async () => {
     const onClick = vi.fn();
-    render(<GameBoard cols="2" rows="2" width="200" handleCellClick={onClick} />);
+    render(<GameBoard cols="2" rows="2" gameName="Morpion" handleCellClick={onClick} />);
     await userEvent.click(document.getElementById('c11')!);
     expect(onClick).toHaveBeenCalledOnce();
   });
 
   it('renders cellsContent in the correct cell', () => {
     const content = { c11: <span data-testid="token">X</span> };
-    render(<GameBoard cols="2" rows="2" width="200" handleCellClick={noop} cellsContent={content} />);
+    render(<GameBoard cols="2" rows="2" gameName="Morpion" handleCellClick={noop} cellsContent={content} />);
     expect(screen.getByTestId('token')).toBeInTheDocument();
   });
 
   it('last column cell has a different right border than other cells', () => {
-    render(<GameBoard cols="3" rows="1" width="300" handleCellClick={noop} />);
+    render(<GameBoard cols="3" rows="1" gameName="Morpion" handleCellClick={noop} />);
     const middleCell = document.getElementById('c21')!;
     const lastCell = document.getElementById('c31')!;
     // jsdom normalises border values — compare relative to each other
@@ -41,9 +41,20 @@ describe('GameBoard', () => {
   });
 
   it('last row cell has a different bottom border than other cells', () => {
-    render(<GameBoard cols="1" rows="3" width="300" handleCellClick={noop} />);
+    render(<GameBoard cols="1" rows="3" gameName="Morpion" handleCellClick={noop} />);
     const middleCell = document.getElementById('c12')!;
     const lastCell = document.getElementById('c13')!;
     expect(middleCell.getAttribute('style')).not.toBe(lastCell.getAttribute('style'));
+  });
+
+  it('renders both jouability-guard and game-grid in the DOM', () => {
+    render(<GameBoard cols="3" rows="3" gameName="Morpion" handleCellClick={noop} />);
+    expect(document.querySelector('.jouability-guard')).toBeInTheDocument();
+    expect(document.querySelector('.game-grid')).toBeInTheDocument();
+  });
+
+  it('guard message contains the gameName', () => {
+    render(<GameBoard cols="7" rows="6" gameName="Puissance 4" handleCellClick={noop} />);
+    expect(document.querySelector('.jouability-guard')?.textContent).toContain('Puissance 4');
   });
 });

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -18,7 +18,9 @@ export function Home() {
   return (
     <div className="home-layout">
       <Header ioClose={ioClose}/>
-      <Outlet />
+      <div className="home-content">
+        <Outlet />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- **Story 3.1** — Remplace le prop `width` fixe de `GameBoard` par un layout CSS fluide : `aspect-ratio`, `container-type: size`, `min(100cqw, calc(100cqh * cols/rows))` pour que la grille s'adapte à la dimension contraignante (largeur ou hauteur)
- **Story 3.2** — Jouability guard CSS-only via `@container` : message affiché et grille masquée quand le container est trop petit (seuil 44px × cols)
- Layout global : `home-content` en `flex: 1` pour que les pages de jeu occupent l'espace restant sous le header
- La `Box` est retirée des pages de jeu ; la bordure est portée directement par `.GameBoard`
- Un wrapper `.game-area` par page de jeu fournit une hauteur résolue pour les container queries

## Test plan

- [ ] Morpion, Puissance4, Reversi : grille aux bonnes proportions sur desktop (largeur contraignante)
- [ ] Portrait mobile 375px : grille aux bonnes proportions (largeur contraignante)
- [ ] Paysage mobile : grille aux bonnes proportions (hauteur contraignante)
- [ ] Jouability guard : message affiché sous 132px (Morpion), 308px (Puissance4), 352px (Reversi)
- [ ] Rotation portrait→paysage : guard disparaît sans rechargement JS
- [ ] Dashboard : occupe bien toute la hauteur disponible
- [ ] Pas de scroll vertical sur aucune page de jeu

Closes #59
Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)